### PR TITLE
Fix certification page when filtered by rome code

### DIFF
--- a/lib/vae/helpers/string.ex
+++ b/lib/vae/helpers/string.ex
@@ -17,9 +17,14 @@ defmodule Vae.String do
 
   def to_id(param) when is_binary(param) do
     param
+    |> to_id_string()
+    |> String.to_integer()
+  end
+
+  def to_id_string(param) when is_binary(param) do
+    param
     |> String.split("-")
     |> List.first()
-    |> String.to_integer()
   end
 
   def to_id(_param), do: nil

--- a/lib/vae_web/controllers/certification_controller.ex
+++ b/lib/vae_web/controllers/certification_controller.ex
@@ -32,9 +32,10 @@ defmodule VaeWeb.CertificationController do
     @options param: :rome_code,
              default: nil
     filter rome_code(query, value, _conn) do
+      code = Vae.String.to_id_string value
       query
       |> join(:inner, [r], r in assoc(r, :romes))
-      |> where([c, r], r.code == ^value)
+      |> where([c, r], r.code == ^code)
     end
   end
 


### PR DESCRIPTION
This PR fixes `/diplomes?rome_code=D1101-boucherie` pages not displaying any result. 